### PR TITLE
Workaround frozen derivation loading animation issue

### DIFF
--- a/lib/src/features/greatwall/presentation/pages/confirmation_page.dart
+++ b/lib/src/features/greatwall/presentation/pages/confirmation_page.dart
@@ -34,11 +34,7 @@ class ConfirmationPage extends StatelessWidget {
       ),
       body: BlocBuilder<GreatWallBloc, GreatWallState>(
         builder: (context, state) {
-          if (state is GreatWallDeriveInProgress) {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
-          } else if (state is GreatWallInitialSuccess) {
+          if (state is GreatWallInitialSuccess) {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/src/features/greatwall/presentation/pages/derivation_level_page.dart
+++ b/lib/src/features/greatwall/presentation/pages/derivation_level_page.dart
@@ -35,11 +35,7 @@ class DerivationLevelPage extends StatelessWidget {
       body: Center(
         child: BlocBuilder<GreatWallBloc, GreatWallState>(
           builder: (context, state) {
-            if (state is GreatWallDeriveInProgress) {
-              return const Center(
-                child: CircularProgressIndicator(),
-              );
-            } else if (state is GreatWallDeriveStepSuccess) {
+            if (state is GreatWallDeriveStepSuccess) {
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
@@ -96,7 +92,7 @@ class DerivationLevelPage extends StatelessWidget {
               );
             } else {
               return const Center(
-                child: Text('Loading or no level data available.'),
+                child: Text('Derivation in progress. Be patient, this will take some time...'),
               );
             }
           },


### PR DESCRIPTION
## Changes in detail:
This PR deletes Circular Progress indicator in Derivation level page.

## What problem does this change solve?
This PR resolves issue: #41 


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
