### PR TITLE
Convert KA into 12-words bip39 and copy to clipboard

### DIFF
--- a/lib/src/features/greatwall/presentation/pages/derivation_result_page.dart
+++ b/lib/src/features/greatwall/presentation/pages/derivation_result_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:t3_formosa/formosa.dart';
 
 import '../../../../common/settings/presentation/pages/settings_page.dart';
 import '../../../memorization_assistant/presentation/blocs/blocs.dart';
@@ -14,7 +15,6 @@ class DerivationResultPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('GreatWall Derivation Result'),
@@ -73,6 +73,25 @@ class DerivationResultPage extends StatelessWidget {
                   ),
                   const SizedBox(height: 10),
                   ElevatedButton(
+                    onPressed: () async {
+                      // Copy the seed to the clipboard for a limited time
+                      Clipboard.setData(ClipboardData(
+                          text: bip39Derivation(state.derivationHashResult)));
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                            content: Text('Seed copied to clipboard')),
+                      );
+
+                      // Allow copying for 10 seconds, then disable
+                      await Future.delayed(const Duration(seconds: 10));
+
+                      // Clear clipboard after the time limit
+                      Clipboard.setData(const ClipboardData(text: ''));
+                    },
+                    child: const Text('Generate and copy seed'),
+                  ),
+                  const SizedBox(height: 10),
+                  ElevatedButton(
                     onPressed: () {
                       context
                           .read<MemoCardSetBloc>()
@@ -90,5 +109,15 @@ class DerivationResultPage extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  String bip39Derivation(String key) {
+    // Convert the derivation hash result to a Uint8List
+    Uint8List derivationHashResultBytes = Uint8List.fromList(
+      key.codeUnits.take(16).toList(), // Take the first 16 bytes
+    );
+
+    Formosa formosa = Formosa(formosaTheme: FormosaTheme.bip39);
+    return formosa.toFormosa(derivationHashResultBytes);
   }
 }


### PR DESCRIPTION
This changes have been created on top of #34 
## Changes in detail:
This pull request introduces next changes:
- Added a "Generate and copy seed" button in the `DerivationResultPage`.
- The button generates a 12-word BIP39 seed from the first 16 bytes of the derivation result (`state.derivationHashResult`) using the t3-formosa-dart library.
- The generated seed can be copied to the clipboard for 10 seconds, after which the clipboard is cleared.
- Updated the UI to provide feedback when the seed is copied and when the clipboard is cleared after the time limit.
## What problem does this change solve?
Solve next issues:
- #69 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct